### PR TITLE
Add debug utils message callback for vulkan

### DIFF
--- a/backend/renderer/vulkan/command_buffer.cpp
+++ b/backend/renderer/vulkan/command_buffer.cpp
@@ -84,7 +84,7 @@ namespace pbrlib::backend::vk
             marker_info.color[3] = 1.0f;
         }
 
-        const auto& functions = _device.vulkanFunctions();
+        const auto& functions = _device.deviceFunctions();
 
         if (functions.vkCmdDebugMarkerBeginEXT) [[likely]]
             functions.vkCmdDebugMarkerBeginEXT(handle, &marker_info);

--- a/backend/renderer/vulkan/config.hpp
+++ b/backend/renderer/vulkan/config.hpp
@@ -3,5 +3,5 @@
 namespace pbrlib::backend::vk::config
 {
     constexpr bool enable_vulkan_set_obj_name   = true;
-    constexpr bool enable_vulkan_debug_print    = true;
+    constexpr bool enable_vulkan_debug_print    = false;
 }

--- a/backend/renderer/vulkan/config.hpp
+++ b/backend/renderer/vulkan/config.hpp
@@ -3,5 +3,5 @@
 namespace pbrlib::backend::vk::config
 {
     constexpr bool enable_vulkan_set_obj_name   = true;
-    constexpr bool enable_vulkan_debug_print    = false;
+    constexpr bool enable_vulkan_debug_print    = true;
 }

--- a/backend/renderer/vulkan/device.cpp
+++ b/backend/renderer/vulkan/device.cpp
@@ -42,7 +42,9 @@ namespace pbrlib::backend::vk
 
         ResourceDestroyer::initForDeviceResources(
             _instance_handle,
+            &_instance_functions,
             _device_handle,
+            &_device_functions,
             _allocator_handle
         );
 
@@ -94,6 +96,9 @@ namespace pbrlib::backend::vk
         VK_CHECK(vkCreateInstance(&instance_info, nullptr, &_instance_handle.handle()));
 
         loadInstanceFunctions();
+
+        if (is_debug) [[unlikely]]
+            setupDebugUtilsMessenger();
     }
 
     std::vector<const char*> Device::instanceExtensions()
@@ -843,5 +848,70 @@ namespace pbrlib::backend::vk
 
         _tracy_ctx_handle = TracyCtxHandle(tracy_ctx_handle);
 #endif
+    }
+}
+
+namespace pbrlib::backend::vk
+{
+    VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsMessageCallback(
+        VkDebugUtilsMessageSeverityFlagBitsEXT      severity,
+        VkDebugUtilsMessageTypeFlagsEXT             type,
+        const VkDebugUtilsMessengerCallbackDataEXT* ptr_callback_data,
+        void*                                       ptr_user_data
+    )
+    {
+        if (!ptr_callback_data || !ptr_callback_data->pMessage) [[unlikely]]
+            return VK_FALSE;
+
+        constexpr auto prefix = [] (VkDebugUtilsMessageTypeFlagsEXT type)
+        {
+            if (type & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)
+                return "validation";
+            
+            if (type & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
+                return "performance";
+
+            return "general";
+        };
+
+        std::string header = std::format("[{}]", prefix(type));
+        
+        if (ptr_callback_data->pMessageIdName)
+            header += std::format("[{}]", ptr_callback_data->pMessageIdName);
+        else 
+            header += "[no-id]";
+
+        if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+            log::error("[vk-device][{}] {}", header, ptr_callback_data->pMessage);
+        else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+            log::warning("[vk-device][{}] {}", header, ptr_callback_data->pMessage);
+        else
+            log::info("[vk-device][{}] {}", header, ptr_callback_data->pMessage);
+
+        return severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT ? VK_TRUE : VK_FALSE;
+    }
+
+    void Device::setupDebugUtilsMessenger()
+    {
+        if (!_instance_functions.vkCreateDebugUtilsMessengerEXT) [[unlikely]]
+        {
+            log::error("[vk-device] failed to load vkCreateDebugUtilsMessengerEXT, is VK_EXT_debug_utils extension enabled?");
+            return ;
+        }
+
+        const VkDebugUtilsMessengerCreateInfoEXT messenger_create_info 
+        { 
+            .sType              = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+            .messageSeverity    = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
+            .messageType        = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+            .pfnUserCallback    = debugUtilsMessageCallback
+        };
+
+        VK_CHECK(_instance_functions.vkCreateDebugUtilsMessengerEXT(
+            _instance_handle, 
+            &messenger_create_info, 
+            nullptr, 
+            &_debug_utils_messenger_handle.handle()
+        ));
     }
 }

--- a/backend/renderer/vulkan/device.cpp
+++ b/backend/renderer/vulkan/device.cpp
@@ -28,7 +28,7 @@ namespace pbrlib::backend::vk
     Device::~Device()
     {
         if (_device_handle != VK_NULL_HANDLE) [[likely]]
-        vkDeviceWaitIdle(_device_handle);
+            vkDeviceWaitIdle(_device_handle);
     }
 
     void Device::init()
@@ -45,8 +45,6 @@ namespace pbrlib::backend::vk
             _device_handle,
             _allocator_handle
         );
-
-        loadFunctions();
 
         createCommandPools();
 
@@ -77,7 +75,8 @@ namespace pbrlib::backend::vk
 
         if (is_debug) [[unlikely]]
         {
-            constexpr std::array layers {
+            constexpr std::array layers 
+            {
                 "VK_LAYER_LUNARG_api_dump",
                 "VK_LAYER_KHRONOS_validation"
             };
@@ -93,6 +92,8 @@ namespace pbrlib::backend::vk
         instance_info.ppEnabledExtensionNames   = extensions.data();
 
         VK_CHECK(vkCreateInstance(&instance_info, nullptr, &_instance_handle.handle()));
+
+        loadInstanceFunctions();
     }
 
     std::vector<const char*> Device::instanceExtensions()
@@ -386,6 +387,8 @@ namespace pbrlib::backend::vk
             &_device_handle.handle()
         ));
 
+        loadDeviceFunctions();
+
         vkGetDeviceQueue(_device_handle, _general_queue.family_index, _general_queue.index, &_general_queue.handle);
     }
 
@@ -565,21 +568,53 @@ namespace pbrlib::backend::vk
         return ptr_function;
     }
 
-    void Device::loadFunctions()
+    template<typename VulkanFunctionType>
+    VulkanFunctionType loadFunction(VkInstance instance_handle, const std::string_view function_name)
+    {
+        auto ptr_function = reinterpret_cast<VulkanFunctionType>(
+            vkGetInstanceProcAddr(
+                instance_handle,
+                function_name.data()
+            )
+        );
+
+        if (ptr_function)
+            log::info("[vk-function-loader] {}", function_name);
+        else
+            log::error("[vk-function-loader] {}", function_name);
+
+        return ptr_function;
+    }
+
+    void Device::loadDeviceFunctions()
     {
         if (config::enable_vulkan_set_obj_name)
-            _functions.vkSetDebugUtilsObjectNameEXT = loadFunction<PFN_vkSetDebugUtilsObjectNameEXT>(_device_handle, "vkSetDebugUtilsObjectNameEXT");
+            _device_functions.vkSetDebugUtilsObjectNameEXT = loadFunction<PFN_vkSetDebugUtilsObjectNameEXT>(_device_handle, "vkSetDebugUtilsObjectNameEXT");
 
         if (isRunFromFrameDebugger()) [[unlikely]]
         {
-            _functions.vkCmdDebugMarkerBeginEXT = loadFunction<PFN_vkCmdDebugMarkerBeginEXT>(_device_handle, "vkCmdDebugMarkerBeginEXT");
-            _functions.vkCmdDebugMarkerEndEXT   = loadFunction<PFN_vkCmdDebugMarkerEndEXT>(_device_handle, "vkCmdDebugMarkerEndEXT");
+            _device_functions.vkCmdDebugMarkerBeginEXT = loadFunction<PFN_vkCmdDebugMarkerBeginEXT>(_device_handle, "vkCmdDebugMarkerBeginEXT");
+            _device_functions.vkCmdDebugMarkerEndEXT   = loadFunction<PFN_vkCmdDebugMarkerEndEXT>(_device_handle, "vkCmdDebugMarkerEndEXT");
         }
     }
 
-    const Functions& Device::vulkanFunctions() const noexcept
+    void Device::loadInstanceFunctions()
     {
-        return _functions;
+        if constexpr (config::enable_vulkan_debug_print)
+        {
+            _instance_functions.vkCreateDebugUtilsMessengerEXT  = loadFunction<PFN_vkCreateDebugUtilsMessengerEXT>(_instance_handle, "vkCreateDebugUtilsMessengerEXT");
+            _instance_functions.vkDestroyDebugUtilsMessengerEXT = loadFunction<PFN_vkDestroyDebugUtilsMessengerEXT>(_instance_handle, "vkDestroyDebugUtilsMessengerEXT");
+        }
+    }
+
+    const DeviceFunctions& Device::deviceFunctions() const noexcept
+    {
+        return _device_functions;
+    }
+
+    const InstanceFunctions& Device::instanceFunctions() const noexcept
+    {
+        return _instance_functions;
     }
 }
 
@@ -587,8 +622,8 @@ namespace pbrlib::backend::vk
 {
     void Device::setName(const VkDebugUtilsObjectNameInfoEXT& name_info) const
     {
-        if (_functions.vkSetDebugUtilsObjectNameEXT) [[likely]]
-            _functions.vkSetDebugUtilsObjectNameEXT(_device_handle, &name_info);
+        if (_device_functions.vkSetDebugUtilsObjectNameEXT) [[likely]]
+            _device_functions.vkSetDebugUtilsObjectNameEXT(_device_handle, &name_info);
     }
 }
 

--- a/backend/renderer/vulkan/device.hpp
+++ b/backend/renderer/vulkan/device.hpp
@@ -26,12 +26,18 @@ namespace pbrlib::backend::vk
         uint32_t    family_index    = std::numeric_limits<uint32_t>::max();
     };
 
-    struct Functions final
+    struct DeviceFunctions final
     {
         PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = VK_NULL_HANDLE;
 
         PFN_vkCmdDebugMarkerBeginEXT    vkCmdDebugMarkerBeginEXT    = VK_NULL_HANDLE;
         PFN_vkCmdDebugMarkerEndEXT      vkCmdDebugMarkerEndEXT      = VK_NULL_HANDLE;
+    };
+
+    struct InstanceFunctions final
+    {
+        PFN_vkCreateDebugUtilsMessengerEXT  vkCreateDebugUtilsMessengerEXT  = VK_NULL_HANDLE;
+        PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT = VK_NULL_HANDLE;
     };
 
     struct DescriptorImageInfo final
@@ -64,7 +70,8 @@ namespace pbrlib::backend::vk
         void createGpuAllocator();
         void createCommandPools();
 
-        void loadFunctions();
+        void loadDeviceFunctions();
+        void loadInstanceFunctions();
 
         void createDescriptorPool();
 
@@ -103,7 +110,8 @@ namespace pbrlib::backend::vk
 
         [[nodiscard]] DescriptorSetHandle allocateDescriptorSet(VkDescriptorSetLayout desc_set_layout_handle, std::string_view name = "") const;
 
-        [[nodiscard]] const Functions& vulkanFunctions() const noexcept;
+        [[nodiscard]] const DeviceFunctions&    deviceFunctions()   const noexcept;
+        [[nodiscard]] const InstanceFunctions&  instanceFunctions() const noexcept;
 
         void setName(const VkDebugUtilsObjectNameInfoEXT& name_info) const;
 
@@ -150,7 +158,8 @@ namespace pbrlib::backend::vk
 
         AllocatorHandle _allocator_handle;
 
-        Functions _functions;
+        DeviceFunctions     _device_functions;
+        InstanceFunctions   _instance_functions;
 
         DescriptorPoolHandle _descriptor_pool_handle;
 

--- a/backend/renderer/vulkan/device.hpp
+++ b/backend/renderer/vulkan/device.hpp
@@ -65,6 +65,7 @@ namespace pbrlib::backend::vk
         void getGeneralQueueIndex();
 
         void createInstance(bool is_debug);
+        void setupDebugUtilsMessenger();
         void getPhysicalDevice();
         void createDevice();
         void createGpuAllocator();
@@ -162,6 +163,8 @@ namespace pbrlib::backend::vk
         InstanceFunctions   _instance_functions;
 
         DescriptorPoolHandle _descriptor_pool_handle;
+
+        DebugUtilsMessengerHandle _debug_utils_messenger_handle; 
 
 #ifdef PBRLIB_ENABLE_PROFILING
         TracyCtxHandle _tracy_ctx_handle;

--- a/backend/renderer/vulkan/unique_handler.cpp
+++ b/backend/renderer/vulkan/unique_handler.cpp
@@ -1,35 +1,48 @@
 #include <backend/renderer/vulkan/unique_handler.hpp>
+#include <backend/renderer/vulkan/device.hpp>
 #include <backend/logger/logger.hpp>
 
 #include <pbrlib/exceptions.hpp>
 
 namespace pbrlib::backend::vk
 {
-    VkInstance      ResourceDestroyer::_instance_handle     = VK_NULL_HANDLE;
-    VkDevice        ResourceDestroyer::_device_handle       = VK_NULL_HANDLE;
-    VmaAllocator    ResourceDestroyer::_allocator_handle    = VK_NULL_HANDLE;
+    VkInstance          ResourceDestroyer::_instance_handle         = VK_NULL_HANDLE;
+    InstanceFunctions*  ResourceDestroyer::_ptr_instance_functions  = nullptr;
+    VkDevice            ResourceDestroyer::_device_handle           = VK_NULL_HANDLE;
+    DeviceFunctions*    ResourceDestroyer::_ptr_device_functions    = nullptr;
+    VmaAllocator        ResourceDestroyer::_allocator_handle        = VK_NULL_HANDLE;
 }
 
 namespace pbrlib::backend::vk
 {
     void ResourceDestroyer::initForDeviceResources (
-        VkInstance      instance_handle,
-        VkDevice        device_handle,
-        VmaAllocator    allocator_handle
+        VkInstance          instance_handle,
+        InstanceFunctions*  ptr_instance_functions,
+        VkDevice            device_handle,
+        DeviceFunctions*    ptr_device_functions,
+        VmaAllocator        allocator_handle
     )
     {
         if (instance_handle == VK_NULL_HANDLE) [[unlikely]]
             throw exception::InvalidArgument("[vk-handle-dispatcher] instance handle is null");
 
+        if (!ptr_instance_functions) [[unlikely]]
+            throw exception::InvalidArgument("[vk-handle-dispatcher] pointer to instance functions is null");
+
         if (device_handle == VK_NULL_HANDLE) [[unlikely]]
             throw exception::InvalidArgument("[vk-handle-dispatcher] device handle is null");
+
+        if (!ptr_device_functions) [[unlikely]]
+            throw exception::InvalidArgument("[vk-handle-dispatcher] pointer to device functions is null");
 
         if (allocator_handle == VK_NULL_HANDLE) [[unlikely]]
             throw exception::InvalidArgument("[vk-handle-dispatcher] allocator handle is null");
 
-        _instance_handle    = instance_handle;
-        _device_handle      = device_handle;
-        _allocator_handle   = allocator_handle;
+        _instance_handle        = instance_handle;
+        _ptr_instance_functions = ptr_instance_functions;
+        _device_handle          = device_handle;
+        _ptr_device_functions   = ptr_device_functions;
+        _allocator_handle       = allocator_handle;
     }
 
     void ResourceDestroyer::destroy(VkInstance instance_handle) noexcept
@@ -161,6 +174,12 @@ namespace pbrlib::backend::vk
     {
         if (semaphore_handle != VK_NULL_HANDLE)
             vkDestroySemaphore(_device_handle, semaphore_handle, nullptr);
+    }
+
+    void ResourceDestroyer::destroy(VkDebugUtilsMessengerEXT debug_utils_messenger_handle) noexcept
+    {
+        if (debug_utils_messenger_handle && _ptr_instance_functions->vkDestroyDebugUtilsMessengerEXT)
+            _ptr_instance_functions->vkDestroyDebugUtilsMessengerEXT(_instance_handle, debug_utils_messenger_handle, nullptr);
     }
 
 #ifdef PBRLIB_ENABLE_PROFILING

--- a/backend/renderer/vulkan/unique_handler.hpp
+++ b/backend/renderer/vulkan/unique_handler.hpp
@@ -11,6 +11,12 @@
 
 namespace pbrlib::backend::vk
 {
+    struct InstanceFunctions;
+    struct DeviceFunctions;
+}
+
+namespace pbrlib::backend::vk
+{
     class ResourceDestroyer final
     {
     public:
@@ -41,21 +47,26 @@ namespace pbrlib::backend::vk
         static void destroy(VkSwapchainKHR swapchain_handle)                                                noexcept;
         static void destroy(VkFence fence_handle)                                                           noexcept;
         static void destroy(VkSemaphore semaphore_handle)                                                   noexcept;
+        static void destroy(VkDebugUtilsMessengerEXT debug_utils_messenger_handle)                          noexcept;
 
 #ifdef PBRLIB_ENABLE_PROFILING
         static void destroy(TracyVkCtx tracy_ctx_handle) noexcept;
 #endif
 
         static void initForDeviceResources (
-            VkInstance      instance_handle,
-            VkDevice        device_handle,
-            VmaAllocator    allocator_handle
+            VkInstance          instance_handle,
+            InstanceFunctions*  ptr_instance_functions,
+            VkDevice            device_handle,
+            DeviceFunctions*    ptr_device_functions,
+            VmaAllocator        allocator_handle
         );
 
     private:
-        static VkInstance   _instance_handle;
-        static VkDevice     _device_handle;
-        static VmaAllocator _allocator_handle;
+        static VkInstance           _instance_handle;
+        static InstanceFunctions*   _ptr_instance_functions;
+        static VkDevice             _device_handle;
+        static DeviceFunctions*     _ptr_device_functions;
+        static VmaAllocator         _allocator_handle;
     };
 }
 
@@ -126,6 +137,7 @@ namespace pbrlib::backend::vk
     using SwapchainHandle           = UniqueHandle<VkSwapchainKHR>;
     using FenceHandle               = UniqueHandle<VkFence>;
     using SemaphoreHandle           = UniqueHandle<VkSemaphore>;
+    using DebugUtilsMessengerHandle = UniqueHandle<VkDebugUtilsMessengerEXT>;
 
 #ifdef PBRLIB_ENABLE_PROFILING
     using TracyCtxHandle = UniqueHandle<TracyVkCtx>;


### PR DESCRIPTION
Пока что не работает на MacOS
```css
[00:00:49 +03:00] [app] [pbrlib] [runtime-error] [vulkan] vkCreateInstance(&instance_info, nullptr, &_instance_handle.handle())

stacktrace:
Stack trace (most recent call first):
#0 0x0000000104e4e74b in pbrlib::exception::Exception::Exception(std::__1::basic_string_view<char, std::__1::char_traits<char>>) at /Users/asifmamedov/dev/pbrlib/out/build/Clang 17.0.0 arm64-apple-darwin25.1.0/bin/interactive-scene
#1 0x0000000104e4ef5f in pbrlib::exception::RuntimeError::RuntimeError(std::__1::basic_string_view<char, std::__1::char_traits<char>>) at /Users/asifmamedov/dev/pbrlib/out/build/Clang 17.0.0 arm64-apple-darwin25.1.0/bin/interactive-scene
#2 0x0000000104e4f013 in pbrlib::exception::RuntimeError::RuntimeError(std::__1::basic_string_view<char, std::__1::char_traits<char>>) at /Users/asifmamedov/dev/pbrlib/out/build/Clang 17.0.0 arm64-apple-darwin25.1.0/bin/interactive-scene
#3 0x0000000104df2b03 in pbrlib::backend::vk::Device::createInstance(bool) at /Users/asifmamedov/dev/pbrlib/out/build/Clang 17.0.0 arm64-apple-darwin25.1.0/bin/interactive-scene
#4 0x0000000104df2567 in pbrlib::backend::vk::Device::init() at /Users/asifmamedov/dev/pbrlib/out/build/Clang 17.0.0 arm64-apple-darwin25.1.0/bin/interactive-scene
#5 0x0000000104e46957 in pbrlib::Engine::Engine(pbrlib::Config const&) at /Users/asifmamedov/dev/pbrlib/out/build/Clang 17.0.0 arm64-apple-darwin25.1.0/bin/interactive-scene
#6 0x0000000104e479e3 in pbrlib::Engine::Engine(pbrlib::Config const&) at /Users/asifmamedov/dev/pbrlib/out/build/Clang 17.0.0 arm64-apple-darwin25.1.0/bin/interactive-scene
#7 0x0000000104cc02c3 in main at /Users/asifmamedov/dev/pbrlib/samples/interactive-scene/main.cpp:86:24
#8 0x0000000193159d53 in start + 7183 at /usr/lib/dyld
```